### PR TITLE
Add zustand store for character counter

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/styled": "^11.6.0",
     "@mui/icons-material": "^5.3.1",
     "@mui/material": "^5.3.1",
+    "zustand": "^3.7.0",
     "grapheme-splitter": "^1.0.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,48 +1,26 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React from "react";
 import { TextField } from "@mui/material";
 import "./App.css";
 import { OutputForm } from "./components/OutputForm";
 import { Header } from "./components/Header";
 import { Buttons } from "./components/Buttons";
-import GraphemeSplitter from "grapheme-splitter";
+import { useStore } from "./store";
 
 function App() {
-  const [text, setText] = useState("");
-  const [length, setLength] = useState(0);
-  const [lengthNoCR, setLengthNoCR] = useState(0);
-  const [lengthNoSpace, setLengthNoSpace] = useState(0);
-  const [numWords, setNumWords] = useState(0);
+  const {
+    text,
+    setText,
+    clearText,
+    readClipboard,
+    length,
+    lengthNoCR,
+    lengthNoSpace,
+    numWords,
+  } = useStore();
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setText(e.target.value);
   };
-  const splitter = new GraphemeSplitter();
-
-  const changeLength = () => {
-    setLength(splitter.countGraphemes(text));
-    let textWithoutCR = text.replace(/\n/g, "");
-    setLengthNoCR(splitter.countGraphemes(textWithoutCR));
-    let textWithoutSpace = textWithoutCR.replace(/\s+/g, "");
-    setLengthNoSpace(splitter.countGraphemes(textWithoutSpace));
-    let textNumWords = text === "" ? 0 : text.trim().split(/\s+/).length;
-    setNumWords(textNumWords);
-  };
-
-  useEffect(() => {
-    changeLength();
-  }, [text]);
-
-  const clearText = useCallback(() => {
-    setText("");
-  }, [setText]);
-
-  const readClipBord = useCallback(() => {
-    navigator.clipboard
-      .readText()
-      .then((data) => {
-        setText(data);
-      })
-      .catch((e) => console.log(e));
-  }, [setText]);
 
   return (
     <div className="App">
@@ -57,7 +35,7 @@ function App() {
         value={text}
       />
       <div className="buttons">
-        <Buttons readClipBord={readClipBord} clearText={clearText} />
+        <Buttons readClipboard={readClipboard} clearText={clearText} />
       </div>
       <div
         style={{

--- a/src/components/Buttons.tsx
+++ b/src/components/Buttons.tsx
@@ -1,24 +1,25 @@
-import React, { memo } from "react";
+import React from "react";
 import { Button } from "@mui/material";
-type props = {
-  readClipBord: VoidFunction;
+
+type Props = {
+  readClipboard: VoidFunction;
   clearText: VoidFunction;
 };
 
-export const Buttons: React.VFC<props> = memo(({ readClipBord, clearText }) => {
+export const Buttons: React.VFC<Props> = ({ readClipboard, clearText }) => {
   return (
     <div className="buttons">
       <Button
         variant="outlined"
         color="primary"
         sx={{ marginRight: "5px" }}
-        onClick={() => readClipBord()}
+        onClick={readClipboard}
       >
         クリップボードの内容を貼り付ける
       </Button>
-      <Button variant="outlined" color="error" onClick={() => clearText()}>
+      <Button variant="outlined" color="error" onClick={clearText}>
         文字をクリアする
       </Button>
     </div>
   );
-});
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,10 @@
-﻿import { memo } from "react";
-
-export const Header = memo(() => {
+export const Header = () => {
   return (
-      <header>
-          文字数カウンター
-          <div id="head-desc">「クリップボードの内容を貼り付ける」ボタンの使用は、ユーザー（ブラウザ）の許可が必要です。</div>
-      </header>
+    <header>
+      文字数カウンター
+      <div id="head-desc">
+        「クリップボードの内容を貼り付ける」ボタンの使用は、ユーザー（ブラウザ）の許可が必要です。
+      </div>
+    </header>
   );
-});
+};

--- a/src/components/OutputForm.tsx
+++ b/src/components/OutputForm.tsx
@@ -1,18 +1,18 @@
-﻿import {
+import {
   FormControl,
   FormHelperText,
   InputAdornment,
   OutlinedInput,
 } from "@mui/material";
-import React, { memo } from "react";
+import React from "react";
 
-type props = {
-  length: Number;
-  desc: String;
-  unit: String;
+type Props = {
+  length: number;
+  desc: string;
+  unit: string;
 };
 
-export const OutputForm: React.VFC<props> = memo(({ length, desc, unit }) => {
+export const OutputForm: React.VFC<Props> = ({ length, desc, unit }) => {
   return (
     <FormControl sx={{ m: 1, width: "30ch" }} variant="outlined">
       <OutlinedInput
@@ -28,4 +28,4 @@ export const OutputForm: React.VFC<props> = memo(({ length, desc, unit }) => {
       <FormHelperText id="outlined-weight-helper-text">{desc}</FormHelperText>
     </FormControl>
   );
-});
+};

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,43 @@
+import { create } from "zustand";
+import GraphemeSplitter from "grapheme-splitter";
+
+interface StoreState {
+  text: string;
+  length: number;
+  lengthNoCR: number;
+  lengthNoSpace: number;
+  numWords: number;
+  setText: (value: string) => void;
+  clearText: () => void;
+  readClipboard: () => void;
+}
+
+const splitter = new GraphemeSplitter();
+
+export const useStore = create<StoreState>((set, get) => ({
+  text: "",
+  length: 0,
+  lengthNoCR: 0,
+  lengthNoSpace: 0,
+  numWords: 0,
+  setText: (value: string) => {
+    const length = splitter.countGraphemes(value);
+    const textWithoutCR = value.replace(/\n/g, "");
+    const lengthNoCR = splitter.countGraphemes(textWithoutCR);
+    const textWithoutSpace = textWithoutCR.replace(/\s+/g, "");
+    const lengthNoSpace = splitter.countGraphemes(textWithoutSpace);
+    const numWords = value === "" ? 0 : value.trim().split(/\s+/).length;
+    set({ text: value, length, lengthNoCR, lengthNoSpace, numWords });
+  },
+  clearText: () => {
+    set({ text: "", length: 0, lengthNoCR: 0, lengthNoSpace: 0, numWords: 0 });
+  },
+  readClipboard: async () => {
+    try {
+      const data = await navigator.clipboard.readText();
+      get().setText(data);
+    } catch (e) {
+      console.log(e);
+    }
+  },
+}));


### PR DESCRIPTION
## Summary
- manage application state via zustand
- simplify components by removing memoization
- update package.json with zustand dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68559ea651f08332865d8d8c8f19f452